### PR TITLE
fix: overlay path in workflow.yaml

### DIFF
--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -5,7 +5,7 @@ sources:
         inputs:
             - location: openapi.json
         overlays:
-            - location: .speakeasy\speakeasy-modifications-overlay.yaml
+            - location: .speakeasy/speakeasy-modifications-overlay.yaml
         registry:
             location: registry.speakeasyapi.dev/d-stoll/attio-js/attio-api
 targets:


### PR DESCRIPTION
This should fix the path error show in the [generation action logs](https://github.com/d-stoll/attio-js/actions/runs/17703913787/job/50313044611) 

> Error: failed to parse overlay from path ".speakeasy\\speakeasy-modifications-overlay.yaml": failed to open overlay file at path ".speakeasy\\speakeasy-modifications-overlay.yaml": open /github/workspace/repo/.speakeasy\speakeasy-modifications-overlay.yaml: no such file or directory